### PR TITLE
Bills look for more things when counting items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,7 @@ __pycache__/
 *.exe
 
 ThirdParty/HugsLib.xml
+About
+Defs
+Languages
+Textures

--- a/Detours/BillConfig_DoWindowContents_Patch.cs
+++ b/Detours/BillConfig_DoWindowContents_Patch.cs
@@ -386,19 +386,19 @@ namespace ImprovedWorkbenches
             if (thingDef.IsApparel)
             {
                 var nonDeadmansApparelFilter = new SpecialThingFilterWorker_NonDeadmansApparel();
-                if (!nonDeadmansApparelFilter.CanEverMatch(thingDef))
+                if (nonDeadmansApparelFilter.CanEverMatch(thingDef))
                 {
-                    // Thing can't be worn.
-                    return;
+                    y += 26;
+                    var rect3 = new Rect(0f, y, columnWidth, buttonHeight);
+                    Widgets.CheckboxLabeled(rect3, "IW.CountCorpseClothesLabel".Translate(),
+                        ref extendedBillData.AllowDeadmansApparel);
+                    TooltipHandler.TipRegion(rect3,
+                        "IW.CountCorpseClothesDesc".Translate());
                 }
-
-                y += 26;
-                var rect3 = new Rect(0f, y, columnWidth, buttonHeight);
-                Widgets.CheckboxLabeled(rect3, "IW.CountCorpseClothesLabel".Translate(),
-                    ref extendedBillData.AllowDeadmansApparel);
-                TooltipHandler.TipRegion(rect3,
-                    "IW.CountCorpseClothesDesc".Translate());
-
+            }
+            // Worn Apparel Filter (includes Shield Belts which cannot be Deadman)
+            if (thingDef.IsApparel || thingDef == ThingDefOf.Apparel_ShieldBelt)
+            { 
                 y += 26;
                 var rect4 = new Rect(0f, y, columnWidth, buttonHeight);
                 Widgets.CheckboxLabeled(rect4, "IW.CountEquippedClothesLabel".Translate(),
@@ -407,7 +407,7 @@ namespace ImprovedWorkbenches
                     "IW.CountEquippedClothesDesc".Translate());
             }
 
-            // Equippped weapon count filter
+            // Equipped weapon count filter
             if (thingDef.IsWeapon)
             {
                 y += 26;

--- a/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
+++ b/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
@@ -84,6 +84,14 @@ namespace ImprovedWorkbenches
                         if (statFilterWrapper.DoesThingMatchFilter(bill.ingredientFilter, apparel))
                             __result++;
                     }
+                    foreach (var apparel in colonist.inventory.innerContainer)
+                    {
+                        if (apparel.def != productThingDef)
+                            continue;
+
+                        if (statFilterWrapper.DoesThingMatchFilter(bill.ingredientFilter, apparel))
+                            __result++;
+                    }
                 }
             }
 
@@ -92,6 +100,14 @@ namespace ImprovedWorkbenches
                 foreach (var colonist in Find.VisibleMap.mapPawns.FreeColonists)
                 {
                     foreach (var weapon in colonist.equipment.AllEquipmentListForReading)
+                    {
+                        if (weapon.def != productThingDef)
+                            continue;
+
+                        if (statFilterWrapper.DoesThingMatchFilter(bill.ingredientFilter, weapon))
+                            __result++;
+                    }
+                    foreach (var weapon in colonist.inventory.innerContainer)
                     {
                         if (weapon.def != productThingDef)
                             continue;

--- a/Filtering/StatFilterWrapper.cs
+++ b/Filtering/StatFilterWrapper.cs
@@ -34,7 +34,7 @@ namespace ImprovedWorkbenches.Filtering
 
         public bool ShouldCheckWornClothes(ThingDef thingDef)
         {
-            return _extendedBillData.CountWornApparel && thingDef.IsApparel;
+            return _extendedBillData.CountWornApparel && (thingDef.IsApparel || thingDef == ThingDefOf.Apparel_ShieldBelt);
         }
 
         public bool ShouldCheckEquippedWeapons(ThingDef thingDef)


### PR DESCRIPTION
Colonist's inventories are counted along with worn apparel / equipped weapons. This may be yet another option, but the gist should be "It's on a colonist" not necessarily "equipped" , right?

Plus, it includes shield belts now. They are not counted as "apparel" and can't be deadman - so this handles that.

and a bonus .gitignore adding Defs/, Languages/ etc because those are copied files during the build