### PR TITLE
Big updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,7 @@ __pycache__/
 *.exe
 
 ThirdParty/HugsLib.xml
+About
+Defs
+Languages
+Textures

--- a/Custom Storage/ExtendedBillData.cs
+++ b/Custom Storage/ExtendedBillData.cs
@@ -9,6 +9,7 @@ namespace ImprovedWorkbenches
     {
         public ThingFilter OutputFilter = new ThingFilter();
         public bool AllowDeadmansApparel;
+        public bool CountInventory;
         public bool CountWornApparel;
         public bool CountEquippedWeapons;
         public bool UseInputFilter;
@@ -97,6 +98,7 @@ namespace ImprovedWorkbenches
         {
             OutputFilter.CopyAllowancesFrom(other.OutputFilter);
             AllowDeadmansApparel = other.AllowDeadmansApparel;
+            CountInventory = other.CountInventory;
             CountWornApparel = other.CountWornApparel;
             CountEquippedWeapons = other.CountEquippedWeapons;
             UseInputFilter = other.UseInputFilter;
@@ -130,6 +132,7 @@ namespace ImprovedWorkbenches
         {
             Scribe_Deep.Look(ref OutputFilter, "outputFilter", new object[0]);
             Scribe_Values.Look(ref AllowDeadmansApparel, "allowDeadmansApparel", false);
+            Scribe_Values.Look(ref CountInventory, "countInventory", false);
             Scribe_Values.Look(ref CountWornApparel, "countWornApparel", false);
             Scribe_Values.Look(ref CountEquippedWeapons, "countEquippedWeapons", false);
             Scribe_Values.Look(ref UseInputFilter, "useInputFilter", false);

--- a/Custom Storage/ExtendedBillData.cs
+++ b/Custom Storage/ExtendedBillData.cs
@@ -16,7 +16,6 @@ namespace ImprovedWorkbenches
         public string Name;
 
         public Map Map;
-        private int MapId = -1;
 
         private Zone_Stockpile _countingStockpile;
         private string _countingStockpileName = "null";
@@ -160,17 +159,14 @@ namespace ImprovedWorkbenches
             {
                 _countingStockpileName = _countingStockpile?.label ?? "null";
                 _takeToStockpileName = _takeToStockpile?.label ?? "null";
-                MapId = Map?.uniqueID ?? -1;
             }
 
             Scribe_Values.Look(ref _countingStockpileName, "countingStockpile", "null");
             Scribe_Values.Look(ref _takeToStockpileName, "takeToStockpile", "null");
-            Scribe_Values.Look(ref MapId, "MapId", -1);
+            Scribe_References.Look(ref Map, "BillMap");
 
             if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
-                Map = Find.Maps.FirstOrDefault(m => m.uniqueID == MapId) ?? Find.VisibleMap;
-
                 _countingStockpile = _countingStockpileName == "null"
                     ? null
                     : Map.zoneManager.AllZones.FirstOrDefault(z =>

--- a/Custom Storage/ExtendedBillData.cs
+++ b/Custom Storage/ExtendedBillData.cs
@@ -10,6 +10,7 @@ namespace ImprovedWorkbenches
         public ThingFilter OutputFilter = new ThingFilter();
         public bool AllowDeadmansApparel;
         public bool CountInventory;
+        public bool CountAway;
         public bool CountInstalled;
         public bool UseInputFilter;
         public Pawn Worker;
@@ -104,6 +105,7 @@ namespace ImprovedWorkbenches
             OutputFilter.CopyAllowancesFrom(other.OutputFilter);
             AllowDeadmansApparel = other.AllowDeadmansApparel;
             CountInventory = other.CountInventory;
+            CountAway = other.CountAway;
             CountInstalled = other.CountInstalled;
             UseInputFilter = other.UseInputFilter;
             Worker = other.Worker;
@@ -142,6 +144,7 @@ namespace ImprovedWorkbenches
             Scribe_Deep.Look(ref OutputFilter, "outputFilter", new object[0]);
             Scribe_Values.Look(ref AllowDeadmansApparel, "allowDeadmansApparel", false);
             Scribe_Values.Look(ref CountInventory, "countInventory", false);
+            Scribe_Values.Look(ref CountAway, "countAway", false);
             Scribe_Values.Look(ref CountInstalled, "countInstalled", true);
             Scribe_Values.Look(ref UseInputFilter, "useInputFilter", false);
             Scribe_References.Look(ref Worker, "worker");

--- a/Custom Storage/ExtendedBillData.cs
+++ b/Custom Storage/ExtendedBillData.cs
@@ -12,6 +12,7 @@ namespace ImprovedWorkbenches
         public bool CountInventory;
         public bool CountWornApparel;
         public bool CountEquippedWeapons;
+        public bool CountInstalled;
         public bool UseInputFilter;
         public Pawn Worker;
         public string Name;
@@ -101,6 +102,7 @@ namespace ImprovedWorkbenches
             CountInventory = other.CountInventory;
             CountWornApparel = other.CountWornApparel;
             CountEquippedWeapons = other.CountEquippedWeapons;
+            CountInstalled = other.CountInstalled;
             UseInputFilter = other.UseInputFilter;
             Worker = other.Worker;
             _countingStockpile = other._countingStockpile;
@@ -135,6 +137,7 @@ namespace ImprovedWorkbenches
             Scribe_Values.Look(ref CountInventory, "countInventory", false);
             Scribe_Values.Look(ref CountWornApparel, "countWornApparel", false);
             Scribe_Values.Look(ref CountEquippedWeapons, "countEquippedWeapons", false);
+            Scribe_Values.Look(ref CountInstalled, "countInstalled", true);
             Scribe_Values.Look(ref UseInputFilter, "useInputFilter", false);
             Scribe_References.Look(ref Worker, "worker");
             Scribe_Values.Look(ref Name, "name", null);

--- a/Custom Storage/ExtendedBillData.cs
+++ b/Custom Storage/ExtendedBillData.cs
@@ -10,8 +10,6 @@ namespace ImprovedWorkbenches
         public ThingFilter OutputFilter = new ThingFilter();
         public bool AllowDeadmansApparel;
         public bool CountInventory;
-        public bool CountWornApparel;
-        public bool CountEquippedWeapons;
         public bool CountInstalled;
         public bool UseInputFilter;
         public Pawn Worker;
@@ -107,8 +105,6 @@ namespace ImprovedWorkbenches
             OutputFilter.CopyAllowancesFrom(other.OutputFilter);
             AllowDeadmansApparel = other.AllowDeadmansApparel;
             CountInventory = other.CountInventory;
-            CountWornApparel = other.CountWornApparel;
-            CountEquippedWeapons = other.CountEquippedWeapons;
             CountInstalled = other.CountInstalled;
             UseInputFilter = other.UseInputFilter;
             Worker = other.Worker;
@@ -147,12 +143,17 @@ namespace ImprovedWorkbenches
             Scribe_Deep.Look(ref OutputFilter, "outputFilter", new object[0]);
             Scribe_Values.Look(ref AllowDeadmansApparel, "allowDeadmansApparel", false);
             Scribe_Values.Look(ref CountInventory, "countInventory", false);
-            Scribe_Values.Look(ref CountWornApparel, "countWornApparel", false);
-            Scribe_Values.Look(ref CountEquippedWeapons, "countEquippedWeapons", false);
             Scribe_Values.Look(ref CountInstalled, "countInstalled", true);
             Scribe_Values.Look(ref UseInputFilter, "useInputFilter", false);
             Scribe_References.Look(ref Worker, "worker");
             Scribe_Values.Look(ref Name, "name", null);
+
+
+            // Backward compatibilty, combine all settings into inventory
+            bool CountWornApparel = false, CountEquippedWeapons = false;
+            Scribe_Values.Look(ref CountWornApparel, "countWornApparel", false);
+            Scribe_Values.Look(ref CountEquippedWeapons, "countEquippedWeapons", false);
+            CountInventory = CountInventory || CountWornApparel || CountEquippedWeapons;
 
             // Stockpiles need special treatment; they cannot be referenced.
             if (Scribe.mode == LoadSaveMode.Saving)

--- a/Detours/BillConfig_DoWindowContents_Patch.cs
+++ b/Detours/BillConfig_DoWindowContents_Patch.cs
@@ -386,19 +386,19 @@ namespace ImprovedWorkbenches
             if (thingDef.IsApparel)
             {
                 var nonDeadmansApparelFilter = new SpecialThingFilterWorker_NonDeadmansApparel();
-                if (!nonDeadmansApparelFilter.CanEverMatch(thingDef))
+                if (nonDeadmansApparelFilter.CanEverMatch(thingDef))
                 {
-                    // Thing can't be worn.
-                    return;
+                    y += 26;
+                    var rect3 = new Rect(0f, y, columnWidth, buttonHeight);
+                    Widgets.CheckboxLabeled(rect3, "IW.CountCorpseClothesLabel".Translate(),
+                        ref extendedBillData.AllowDeadmansApparel);
+                    TooltipHandler.TipRegion(rect3,
+                        "IW.CountCorpseClothesDesc".Translate());
                 }
-
-                y += 26;
-                var rect3 = new Rect(0f, y, columnWidth, buttonHeight);
-                Widgets.CheckboxLabeled(rect3, "IW.CountCorpseClothesLabel".Translate(),
-                    ref extendedBillData.AllowDeadmansApparel);
-                TooltipHandler.TipRegion(rect3,
-                    "IW.CountCorpseClothesDesc".Translate());
-
+            }
+            // Worn Apparel Filter (includes Shield Belts which cannot be Deadman)
+            if (thingDef.IsApparel || thingDef == ThingDefOf.Apparel_ShieldBelt)
+            { 
                 y += 26;
                 var rect4 = new Rect(0f, y, columnWidth, buttonHeight);
                 Widgets.CheckboxLabeled(rect4, "IW.CountEquippedClothesLabel".Translate(),
@@ -407,7 +407,7 @@ namespace ImprovedWorkbenches
                     "IW.CountEquippedClothesDesc".Translate());
             }
 
-            // Equippped weapon count filter
+            // Equipped weapon count filter
             if (thingDef.IsWeapon)
             {
                 y += 26;

--- a/Detours/BillConfig_DoWindowContents_Patch.cs
+++ b/Detours/BillConfig_DoWindowContents_Patch.cs
@@ -260,7 +260,6 @@ namespace ImprovedWorkbenches
 
             const float buttonHeight = 26f;
             const float smallButtonHeight = 24f;
-            var y = inRect.height - 248f + Text.LineHeight;
 
             // "Unpause when" level adjustment buttons
             if (billRaw.pauseWhenSatisfied)
@@ -297,9 +296,9 @@ namespace ImprovedWorkbenches
                 TooltipHandler.TipRegion(keyboardRect, "IW.RenameTip".Translate());
             }
 
+            var y = inRect.height - 245f + Text.LineHeight;
             // Restrict counting to specific stockpile
             {
-                y += 33;
                 var subRect = new Rect(0f, y, columnWidth, buttonHeight);
                 var anyStockpileText = "IW.CountOnStockpilesText".Translate();
                 var currentCountingStockpileLabel = extendedBillData.UsesCountingStockpile()
@@ -405,7 +404,11 @@ namespace ImprovedWorkbenches
 
             // Inventory Filter
             if (StatFilterWrapper.GoesInInventory(thingDef))
+            {
                 SimpleCheckBox("CountInventory", ref extendedBillData.CountInventory);
+                if (extendedBillData.CountInventory)
+                    SimpleCheckBox("CountAway", ref extendedBillData.CountAway);
+            }
         }
 
         private static void DrawWorkTableNavigation(Dialog_BillConfig dialog, Bill_Production bill, Rect inRect)

--- a/Detours/BillConfig_DoWindowContents_Patch.cs
+++ b/Detours/BillConfig_DoWindowContents_Patch.cs
@@ -347,11 +347,11 @@ namespace ImprovedWorkbenches
                 if (filter.allowedHitPointsConfigurable)
                 {
                     var allowedHitPointsPercents = filter.AllowedHitPointsPercents;
-                    var rect1 = new Rect(0f, y, columnWidth, buttonHeight);
-                    Widgets.FloatRange(rect1, 10, ref allowedHitPointsPercents, 0f, 1f,
+                    var subRect = new Rect(0f, y, columnWidth, buttonHeight);
+                    Widgets.FloatRange(subRect, 10, ref allowedHitPointsPercents, 0f, 1f,
                         "HitPoints", ToStringStyle.PercentZero);
 
-                    TooltipHandler.TipRegion(rect1,
+                    TooltipHandler.TipRegion(subRect,
                         "IW.HitPointsTip".Translate());
                     filter.AllowedHitPointsPercents = allowedHitPointsPercents;
                 }
@@ -359,74 +359,62 @@ namespace ImprovedWorkbenches
                 if (filter.allowedQualitiesConfigurable)
                 {
                     y += 33;
-                    var rect2 = new Rect(0f, y, columnWidth, buttonHeight);
+                    var subRect = new Rect(0f, y, columnWidth, buttonHeight);
                     var allowedQualityLevels = filter.AllowedQualityLevels;
-                    Widgets.QualityRange(rect2, 11, ref allowedQualityLevels);
-                    TooltipHandler.TipRegion(rect2,
+                    Widgets.QualityRange(subRect, 11, ref allowedQualityLevels);
+                    TooltipHandler.TipRegion(subRect,
                         "IW.QualityTip".Translate());
                     filter.AllowedQualityLevels = allowedQualityLevels;
                 }
 
             }
 
+            y += 7;
+
+            //Helper method for checkboxes
+            void SimpleCheckBoxTip(string label, ref bool setting, string tip)
+            {
+                y += 26;
+                var subRect = new Rect(0f, y, columnWidth, buttonHeight);
+                Widgets.CheckboxLabeled(subRect, label.Translate(),
+                    ref setting);
+
+                TooltipHandler.TipRegion(subRect, tip.Translate());
+            };
+            //Super helper method for string construction
+            void SimpleCheckBox(string label, ref bool setting)
+            { SimpleCheckBoxTip("IW." + label + "Label", ref setting, "IW." + label + "Desc"); }
+
             // Use input ingredients for counted items filter
             if (billRaw.ingredientFilter != null && thingDef.MadeFromStuff)
             {
-                y += 33;
-                var subRect = new Rect(0f, y, columnWidth, buttonHeight);
-                Widgets.CheckboxLabeled(subRect, "IW.MatchInputIngredientsText".Translate(),
-                    ref extendedBillData.UseInputFilter);
-
-                TooltipHandler.TipRegion(subRect,
-                    "IW.IngredientsTip".Translate());
+                SimpleCheckBoxTip("IW.MatchInputIngredientsText", ref extendedBillData.UseInputFilter,
+                    "IW.MatchInputIngredientsTip");
             }
 
+            //Installable filter
+            if (thingDef.Minifiable)
+                SimpleCheckBox("CountInstalled", ref extendedBillData.CountInstalled);
 
             // Deadmans clothing count filter
             if (thingDef.IsApparel)
             {
                 var nonDeadmansApparelFilter = new SpecialThingFilterWorker_NonDeadmansApparel();
                 if (nonDeadmansApparelFilter.CanEverMatch(thingDef))
-                {
-                    y += 26;
-                    var rect3 = new Rect(0f, y, columnWidth, buttonHeight);
-                    Widgets.CheckboxLabeled(rect3, "IW.CountCorpseClothesLabel".Translate(),
-                        ref extendedBillData.AllowDeadmansApparel);
-                    TooltipHandler.TipRegion(rect3,
-                        "IW.CountCorpseClothesDesc".Translate());
-                }
+                    SimpleCheckBox("CountCorpseClothes", ref extendedBillData.AllowDeadmansApparel);
             }
+
             // Worn Apparel Filter (includes Shield Belts which cannot be Deadman)
             if (thingDef.IsApparel || thingDef == ThingDefOf.Apparel_ShieldBelt)
-            { 
-                y += 26;
-                var rect4 = new Rect(0f, y, columnWidth, buttonHeight);
-                Widgets.CheckboxLabeled(rect4, "IW.CountEquippedClothesLabel".Translate(),
-                    ref extendedBillData.CountWornApparel);
-                TooltipHandler.TipRegion(rect4,
-                    "IW.CountEquippedClothesDesc".Translate());
-            }
+                SimpleCheckBox("CountEquippedClothes", ref extendedBillData.CountWornApparel);
 
             // Equipped weapon count filter
             else if (thingDef.IsWeapon)
-            {
-                y += 26;
-                var rect5 = new Rect(0f, y, columnWidth, buttonHeight);
-                Widgets.CheckboxLabeled(rect5, "IW.CountEquippedWeaponsLabel".Translate(),
-                    ref extendedBillData.CountEquippedWeapons);
-                TooltipHandler.TipRegion(rect5,
-                    "IW.CountEquippedWeaponsDesc".Translate());
-            }
+                SimpleCheckBox("CountEquippedWeapons", ref extendedBillData.CountEquippedWeapons);
 
+            // Items in Inventory filter
             else if(thingDef.EverHaulable || (thingDef.minifiedDef?.EverHaulable ?? false))
-            {
-                y += 26;
-                var rect6 = new Rect(0f, y, columnWidth, buttonHeight);
-                Widgets.CheckboxLabeled(rect6, "IW.CountInventoryLabel".Translate(),
-                    ref extendedBillData.CountInventory);
-                TooltipHandler.TipRegion(rect6,
-                    "IW.CountInventoryDesc".Translate());
-            }
+                SimpleCheckBox("CountInventory", ref extendedBillData.CountInventory);
         }
 
         private static void DrawWorkTableNavigation(Dialog_BillConfig dialog, Bill_Production bill, Rect inRect)

--- a/Detours/BillConfig_DoWindowContents_Patch.cs
+++ b/Detours/BillConfig_DoWindowContents_Patch.cs
@@ -6,6 +6,7 @@ using Harmony;
 using RimWorld;
 using UnityEngine;
 using Verse;
+using ImprovedWorkbenches.Filtering;
 
 namespace ImprovedWorkbenches
 {
@@ -404,16 +405,8 @@ namespace ImprovedWorkbenches
                     SimpleCheckBox("CountCorpseClothes", ref extendedBillData.AllowDeadmansApparel);
             }
 
-            // Worn Apparel Filter (includes Shield Belts which cannot be Deadman)
-            if (thingDef.IsApparel || thingDef == ThingDefOf.Apparel_ShieldBelt)
-                SimpleCheckBox("CountEquippedClothes", ref extendedBillData.CountWornApparel);
-
-            // Equipped weapon count filter
-            else if (thingDef.IsWeapon)
-                SimpleCheckBox("CountEquippedWeapons", ref extendedBillData.CountEquippedWeapons);
-
-            // Items in Inventory filter
-            else if(thingDef.EverHaulable || (thingDef.minifiedDef?.EverHaulable ?? false))
+            // Inventory Filter
+            if (StatFilterWrapper.GoesInInventory(thingDef))
                 SimpleCheckBox("CountInventory", ref extendedBillData.CountInventory);
         }
 

--- a/Detours/BillConfig_DoWindowContents_Patch.cs
+++ b/Detours/BillConfig_DoWindowContents_Patch.cs
@@ -408,7 +408,7 @@ namespace ImprovedWorkbenches
             }
 
             // Equipped weapon count filter
-            if (thingDef.IsWeapon)
+            else if (thingDef.IsWeapon)
             {
                 y += 26;
                 var rect5 = new Rect(0f, y, columnWidth, buttonHeight);
@@ -416,6 +416,16 @@ namespace ImprovedWorkbenches
                     ref extendedBillData.CountEquippedWeapons);
                 TooltipHandler.TipRegion(rect5,
                     "IW.CountEquippedWeaponsDesc".Translate());
+            }
+
+            else if(thingDef.EverHaulable || (thingDef.minifiedDef?.EverHaulable ?? false))
+            {
+                y += 26;
+                var rect6 = new Rect(0f, y, columnWidth, buttonHeight);
+                Widgets.CheckboxLabeled(rect6, "IW.CountInventoryLabel".Translate(),
+                    ref extendedBillData.CountInventory);
+                TooltipHandler.TipRegion(rect6,
+                    "IW.CountInventoryDesc".Translate());
             }
         }
 

--- a/Detours/Pawn_Spawn_Detour.cs
+++ b/Detours/Pawn_Spawn_Detour.cs
@@ -1,0 +1,39 @@
+﻿//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Text;
+using Harmony;
+using RimWorld.Planet;
+using Verse;
+
+
+namespace ImprovedWorkbenches.Detours
+{
+    //This ought to be ExitMap, but sometimes DeSpawn is called before it :/
+    [HarmonyPatch(typeof(Pawn), "DeSpawn")]
+    class Pawn_DeSpawn_Detour
+    {
+        public static void Prefix(Pawn __instance)
+        {
+            if (__instance.Map.IsPlayerHome && (__instance.Faction?.IsPlayer ?? false))
+            {
+                __instance.SetOriginMap(__instance.Map);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Pawn), "SpawnSetup")]
+    class Pawn_SpawnSetup_Detour
+    {
+        public static void Postfix(Pawn __instance, Map map, bool respawningAfterLoad)
+        {
+            //If NEW ENTERED map is player home, forget ORIGINAL map
+            //ie Don't forget original when you are just raiding an enemy base
+            if (__instance.HasOriginMap() && map.IsPlayerHome)
+            {
+                //Pawn is there ; doesn't need to remember it
+                __instance.SetOriginMap(null); 
+            }
+        }
+    }
+}

--- a/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
+++ b/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
@@ -73,34 +73,34 @@ namespace ImprovedWorkbenches
                 }
             }
 
-            //Who could have this Thing
-            IEnumerable<Pawn> pawns = bill.Map.mapPawns.SpawnedPawnsInFaction(Faction.OfPlayer).Where(
-                p => p.IsFreeColonist || !p.IsColonist);    //Filter out prisoners, include animals (for inventory)
-
-            //Gather the Things
-            List<Thing> pawnThings = new List<Thing>();
-            foreach (var pawn in pawns)
+            if (statFilterWrapper.ShouldCheckInventory(productThingDef))
             {
-                if (statFilterWrapper.ShouldCheckEquippedWeapons(productThingDef) && pawn.equipment != null)
-                    pawnThings.AddRange(pawn.equipment.AllEquipmentListForReading.Cast<Thing>());
-                if (statFilterWrapper.ShouldCheckWornClothes(productThingDef) && pawn.apparel != null)
-                    pawnThings.AddRange(pawn.apparel.WornApparel.Cast<Thing>());
-                if (statFilterWrapper.ShouldCheckInventory(productThingDef))
+                //Who could have this Thing
+                IEnumerable<Pawn> pawns = bill.Map.mapPawns.SpawnedPawnsInFaction(Faction.OfPlayer).Where(
+                    p => p.IsFreeColonist || !p.IsColonist);    //Filter out prisoners, include animals (for inventory)
+
+                List<Thing> pawnThings = new List<Thing>();
+                //Gather the Things
+                foreach (var pawn in pawns)
                 {
+                    if (pawn.apparel != null)
+                        pawnThings.AddRange(pawn.apparel.WornApparel.Cast<Thing>());
+                    if (pawn.equipment != null)
+                        pawnThings.AddRange(pawn.equipment.AllEquipmentListForReading.Cast<Thing>());
                     if (pawn.inventory != null)
                         pawnThings.AddRange(pawn.inventory.innerContainer);
                     if (pawn.carryTracker != null)
                         pawnThings.AddRange(pawn.carryTracker.innerContainer);
                 }
-            }
 
-            //Count the Things
-            foreach (Thing i in pawnThings)
-            {
-                Thing item = MinifyUtility.GetInnerIfMinified(i);
-                if ((item.def == productThingDef && statFilterWrapper.DoesThingMatchFilter(bill.ingredientFilter, item)) &&
-                    (nonDeadmansApparelFilter?.Matches(item) ?? true))
-                    __result += item.stackCount;
+                //Count the Things
+                foreach (Thing i in pawnThings)
+                {
+                    Thing item = MinifyUtility.GetInnerIfMinified(i);
+                    if ((item.def == productThingDef && statFilterWrapper.DoesThingMatchFilter(bill.ingredientFilter, item)) &&
+                        (nonDeadmansApparelFilter?.Matches(item) ?? true))
+                        __result += item.stackCount;
+                }
             }
 
             return false;

--- a/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
+++ b/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
@@ -74,7 +74,7 @@ namespace ImprovedWorkbenches
             }
 
             //Who could have this Thing
-            IEnumerable<Pawn> pawns = Find.VisibleMap.mapPawns.SpawnedPawnsInFaction(Faction.OfPlayer).Where(
+            IEnumerable<Pawn> pawns = bill.Map.mapPawns.SpawnedPawnsInFaction(Faction.OfPlayer).Where(
                 p => p.IsFreeColonist || !p.IsColonist);    //Filter out prisoners, include animals (for inventory)
 
             //Gather the Things

--- a/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
+++ b/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
@@ -46,8 +46,6 @@ namespace ImprovedWorkbenches
                         __result++;
                     }
                 }
-
-                return false;
             }
 
             SpecialThingFilterWorker_NonDeadmansApparel nonDeadmansApparelFilter = null;
@@ -60,17 +58,19 @@ namespace ImprovedWorkbenches
                     nonDeadmansApparelFilter = null;
             }
 
-
-            var thingList = bill.Map.listerThings.ThingsOfDef(productThingDef).ToList();
-            foreach (var thing in thingList)
+            if (statFilterWrapper.ShouldCheckMap(productThingDef))
             {
-                if (!statFilterWrapper.DoesThingOnMapMatchFilter(bill.ingredientFilter, thing))
-                    continue;
+                var thingList = bill.Map.listerThings.ThingsOfDef(productThingDef).ToList();
+                foreach (var thing in thingList)
+                {
+                    if (!statFilterWrapper.DoesThingOnMapMatchFilter(bill.ingredientFilter, thing))
+                        continue;
 
-                if (nonDeadmansApparelFilter != null && !nonDeadmansApparelFilter.Matches(thing))
-                    continue;
+                    if (nonDeadmansApparelFilter != null && !nonDeadmansApparelFilter.Matches(thing))
+                        continue;
 
-                __result += thing.stackCount;
+                    __result += thing.stackCount;
+                }
             }
 
             //Who could have this Thing

--- a/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
+++ b/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
@@ -84,6 +84,14 @@ namespace ImprovedWorkbenches
                         if (statFilterWrapper.DoesThingMatchFilter(bill.ingredientFilter, apparel))
                             __result++;
                     }
+                    foreach (var apparel in colonist.inventory.innerContainer)
+                    {
+                        if (apparel.def != productThingDef)
+                            continue;
+
+                        if (statFilterWrapper.DoesThingMatchFilter(bill.ingredientFilter, apparel))
+                            __result++;
+                    }
                 }
             }
 
@@ -92,6 +100,14 @@ namespace ImprovedWorkbenches
                 foreach (var colonist in Find.VisibleMap.mapPawns.FreeColonists)
                 {
                     foreach (var weapon in colonist.equipment.AllEquipmentListForReading)
+                    {
+                        if (weapon.def != productThingDef)
+                            continue;
+
+                        if (statFilterWrapper.DoesThingMatchFilter(bill.ingredientFilter, weapon))
+                            __result++;
+                    }
+                    foreach (var weapon in colonist.inventory.innerContainer)
                     {
                         if (weapon.def != productThingDef)
                             continue;

--- a/Detours/StoreUtility_TryFindBestBetterStoreCellFor_Patch.cs
+++ b/Detours/StoreUtility_TryFindBestBetterStoreCellFor_Patch.cs
@@ -29,7 +29,8 @@ namespace ImprovedWorkbenches
                 return true;
 
             var stockPile = extendedBillData.GetTakeToStockpile();
-            if (!stockPile.settings.AllowedToAccept(t))
+            if (!stockPile.settings.AllowedToAccept(t)
+                || stockPile.Map != carrier.Map)    //Linked bill to another map?
                 return true;
 
             var cellsList = stockPile.GetSlotGroup().CellsList;

--- a/Filtering/PawnOriginalMapSaver.cs
+++ b/Filtering/PawnOriginalMapSaver.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Verse;
+using RimWorld;
+
+namespace ImprovedWorkbenches
+{
+    public class CompPawnOriginalMap : ThingComp
+    {
+        public Map OriginMap = null;
+
+        public bool HasOriginMap()
+        {
+            return OriginMap != null;
+        }
+
+        public void SetOriginMap(Map map)
+        {
+            OriginMap = map;
+        }
+
+        public override void PostExposeData()
+        {
+            base.PostExposeData();
+            if (parent.Faction?.IsPlayer ?? false)
+            {
+                Scribe_References.Look(ref OriginMap, "OriginMap");
+            }
+        }
+    }
+
+    public static class PawnExtensions
+    {
+        public static bool HasOriginMap(this Pawn pawn)
+        {
+            return (pawn.GetComp<CompPawnOriginalMap>()?.HasOriginMap() ?? false);
+        }
+
+        public static void SetOriginMap(this Pawn pawn, Map map)
+        {
+            pawn.GetComp<CompPawnOriginalMap>()?.SetOriginMap(map);
+        }
+
+        public static Map GetOriginMap(this Pawn pawn)
+        {
+            return (pawn.GetComp<CompPawnOriginalMap>()?.OriginMap ?? null);
+        }
+    }
+}

--- a/Filtering/StatFilterWrapper.cs
+++ b/Filtering/StatFilterWrapper.cs
@@ -34,7 +34,7 @@ namespace ImprovedWorkbenches.Filtering
 
         public bool ShouldCheckWornClothes(ThingDef thingDef)
         {
-            return _extendedBillData.CountWornApparel && thingDef.IsApparel;
+            return _extendedBillData.CountWornApparel && (thingDef.IsApparel || thingDef == ThingDefOf.Apparel_ShieldBelt);
         }
 
         public bool ShouldCheckEquippedWeapons(ThingDef thingDef)

--- a/Filtering/StatFilterWrapper.cs
+++ b/Filtering/StatFilterWrapper.cs
@@ -28,32 +28,26 @@ namespace ImprovedWorkbenches.Filtering
                 || _isQualityFilterNeeded
                 || _extendedBillData.UsesCountingStockpile()
                 || ShouldCheckInventory(thingDef)
-                || ShouldCheckWornClothes(thingDef)
-                || ShouldCheckEquippedWeapons(thingDef)
                 || ShouldCheckDeadman(thingDef)
                 || thingDef.Minifiable;
         }
 
         public bool ShouldCheckInventory(ThingDef thingDef)
         {
-            return (_extendedBillData.CountInventory && (thingDef.EverHaulable || (thingDef.minifiedDef?.EverHaulable ?? false)))
-                || ShouldCheckWornClothes(thingDef)
-                || ShouldCheckEquippedWeapons(thingDef);
+            return _extendedBillData.CountInventory && GoesInInventory(thingDef);
         }
-        
-        public bool ShouldCheckWornClothes(ThingDef thingDef)
+
+        public static bool GoesInInventory(ThingDef thingDef)
         {
-            return _extendedBillData.CountWornApparel && (thingDef.IsApparel || thingDef == ThingDefOf.Apparel_ShieldBelt);
+            // Probably redundant, but I'm sure something out there doesn't match O_o
+            return (thingDef.IsApparel || thingDef == ThingDefOf.Apparel_ShieldBelt ||
+                thingDef.IsWeapon ||
+                (thingDef.minifiedDef?.EverHaulable ?? thingDef.EverHaulable));
         }
 
         public bool ShouldCheckDeadman(ThingDef thingDef)
         {
             return !_extendedBillData.AllowDeadmansApparel && thingDef.IsApparel;
-        }
-
-        public bool ShouldCheckEquippedWeapons(ThingDef thingDef)
-        {
-            return _extendedBillData.CountEquippedWeapons && thingDef.IsWeapon;
         }
 
         public bool ShouldCheckMap(ThingDef thingDef)

--- a/Filtering/StatFilterWrapper.cs
+++ b/Filtering/StatFilterWrapper.cs
@@ -27,14 +27,27 @@ namespace ImprovedWorkbenches.Filtering
                 || _isHitpointsFilterNeeded
                 || _isQualityFilterNeeded
                 || _extendedBillData.UsesCountingStockpile()
+                || ShouldCheckInventory(thingDef)
                 || ShouldCheckWornClothes(thingDef)
                 || ShouldCheckEquippedWeapons(thingDef)
-                || (thingDef.IsApparel && !_extendedBillData.AllowDeadmansApparel);
+                || ShouldCheckDeadman(thingDef);
         }
 
+        public bool ShouldCheckInventory(ThingDef thingDef)
+        {
+            return (_extendedBillData.CountInventory && (thingDef.EverHaulable || (thingDef.minifiedDef?.EverHaulable ?? false)))
+                || ShouldCheckWornClothes(thingDef)
+                || ShouldCheckEquippedWeapons(thingDef);
+        }
+        
         public bool ShouldCheckWornClothes(ThingDef thingDef)
         {
             return _extendedBillData.CountWornApparel && (thingDef.IsApparel || thingDef == ThingDefOf.Apparel_ShieldBelt);
+        }
+
+        public bool ShouldCheckDeadman(ThingDef thingDef)
+        {
+            return !_extendedBillData.AllowDeadmansApparel && thingDef.IsApparel;
         }
 
         public bool ShouldCheckEquippedWeapons(ThingDef thingDef)

--- a/Filtering/StatFilterWrapper.cs
+++ b/Filtering/StatFilterWrapper.cs
@@ -37,6 +37,11 @@ namespace ImprovedWorkbenches.Filtering
             return _extendedBillData.CountInventory && GoesInInventory(thingDef);
         }
 
+        public bool ShouldCheckAway(ThingDef thingDef)
+        {
+            return _extendedBillData.CountAway && GoesInInventory(thingDef);
+        }
+
         public static bool GoesInInventory(ThingDef thingDef)
         {
             // Probably redundant, but I'm sure something out there doesn't match O_o

--- a/Filtering/StatFilterWrapper.cs
+++ b/Filtering/StatFilterWrapper.cs
@@ -50,6 +50,18 @@ namespace ImprovedWorkbenches.Filtering
                 (thingDef.minifiedDef?.EverHaulable ?? thingDef.EverHaulable));
         }
 
+        public SpecialThingFilterWorker_NonDeadmansApparel TryGetDeadmanFilter(ThingDef thingDef)
+        {
+            if (ShouldCheckDeadman(thingDef))
+            {
+                SpecialThingFilterWorker_NonDeadmansApparel nonDeadmansApparelFilter = new SpecialThingFilterWorker_NonDeadmansApparel();
+                if (nonDeadmansApparelFilter.CanEverMatch(thingDef))
+                    // Not apparel, don't bother checking
+                    return nonDeadmansApparelFilter;
+            }
+            return null;
+        }
+
         public bool ShouldCheckDeadman(ThingDef thingDef)
         {
             return !_extendedBillData.AllowDeadmansApparel && thingDef.IsApparel;

--- a/Filtering/StatFilterWrapper.cs
+++ b/Filtering/StatFilterWrapper.cs
@@ -30,7 +30,8 @@ namespace ImprovedWorkbenches.Filtering
                 || ShouldCheckInventory(thingDef)
                 || ShouldCheckWornClothes(thingDef)
                 || ShouldCheckEquippedWeapons(thingDef)
-                || ShouldCheckDeadman(thingDef);
+                || ShouldCheckDeadman(thingDef)
+                || thingDef.Minifiable;
         }
 
         public bool ShouldCheckInventory(ThingDef thingDef)
@@ -53,6 +54,11 @@ namespace ImprovedWorkbenches.Filtering
         public bool ShouldCheckEquippedWeapons(ThingDef thingDef)
         {
             return _extendedBillData.CountEquippedWeapons && thingDef.IsWeapon;
+        }
+
+        public bool ShouldCheckMap(ThingDef thingDef)
+        {
+            return (_extendedBillData.CountInstalled && thingDef.Minifiable) || !thingDef.Minifiable;
         }
 
         public bool DoesThingOnMapMatchFilter(ThingFilter ingredientFilter, Thing thing)

--- a/dist/ImprovedWorkbenches/Languages/ChineseSimplified/Keyed/IW_LanguageData.xml
+++ b/dist/ImprovedWorkbenches/Languages/ChineseSimplified/Keyed/IW_LanguageData.xml
@@ -41,9 +41,9 @@
 	
 	<IW.CountCorpseClothesLabel>计入尸体的衣物</IW.CountCorpseClothesLabel>
 	<IW.CountCorpseClothesDesc>从尸体上扒下来衣物也会被计入</IW.CountCorpseClothesDesc>
-	
-	<IW.CountEquippedClothesLabel>计入已装备的衣物</IW.CountEquippedClothesLabel>
-	<IW.CountEquippedClothesDesc>已经被殖民者装备的衣物也会被计入</IW.CountEquippedClothesDesc>
+
+	<IW.CountInventoryLabel>计入已装备的衣物</IW.CountInventoryLabel>
+	<IW.CountInventoryDesc>已经被殖民者装备的衣物也会被计入</IW.CountInventoryDesc>
 
 	<IW.OpenPreviousBillTip>打开这个工作台的上一个任务清单</IW.OpenPreviousBillTip>
 	

--- a/dist/ImprovedWorkbenches/Languages/English/Keyed/IW_LanguageData.xml
+++ b/dist/ImprovedWorkbenches/Languages/English/Keyed/IW_LanguageData.xml
@@ -42,6 +42,9 @@
   <IW.CountCorpseClothesLabel>Count corpse clothes</IW.CountCorpseClothesLabel>
   <IW.CountCorpseClothesDesc>Include corpse worn clothing in item count</IW.CountCorpseClothesDesc>
 
+  <IW.CountInventoryLabel>Count carried items</IW.CountInventoryLabel>
+  <IW.CountInventoryDesc>Also count items inventories or being carried</IW.CountInventoryDesc>
+
   <IW.CountEquippedClothesLabel>Count equipped clothes</IW.CountEquippedClothesLabel>
   <IW.CountEquippedClothesDesc>Also count clothes currently worn by colonists</IW.CountEquippedClothesDesc>
 

--- a/dist/ImprovedWorkbenches/Languages/English/Keyed/IW_LanguageData.xml
+++ b/dist/ImprovedWorkbenches/Languages/English/Keyed/IW_LanguageData.xml
@@ -42,14 +42,8 @@
   <IW.CountCorpseClothesLabel>Count corpse clothes</IW.CountCorpseClothesLabel>
   <IW.CountCorpseClothesDesc>Include corpse worn clothing in item count</IW.CountCorpseClothesDesc>
 
-  <IW.CountInventoryLabel>Count carried items</IW.CountInventoryLabel>
-  <IW.CountInventoryDesc>Also count items in inventories or being carried</IW.CountInventoryDesc>
-
-  <IW.CountEquippedClothesLabel>Count equipped clothes</IW.CountEquippedClothesLabel>
-  <IW.CountEquippedClothesDesc>Also count clothes currently worn by colonists</IW.CountEquippedClothesDesc>
-
-  <IW.CountEquippedWeaponsLabel>Count equipped weapons</IW.CountEquippedWeaponsLabel>
-  <IW.CountEquippedWeaponsDesc>Also count weapons currently equipped by colonists</IW.CountEquippedWeaponsDesc>
+  <IW.CountInventoryLabel>Count colonist's items</IW.CountInventoryLabel>
+  <IW.CountInventoryDesc>Also count items on any colonist or animal</IW.CountInventoryDesc>
 
   <IW.CountInstalledLabel>Count installed items</IW.CountInstalledLabel>
   <IW.CountInstalledDesc>Also count items that have been installed as a building</IW.CountInstalledDesc>

--- a/dist/ImprovedWorkbenches/Languages/English/Keyed/IW_LanguageData.xml
+++ b/dist/ImprovedWorkbenches/Languages/English/Keyed/IW_LanguageData.xml
@@ -45,6 +45,9 @@
   <IW.CountInventoryLabel>Count colonist's items</IW.CountInventoryLabel>
   <IW.CountInventoryDesc>Also count items on any colonist or animal</IW.CountInventoryDesc>
 
+  <IW.CountAwayLabel>... Even when gone</IW.CountAwayLabel>
+  <IW.CountAwayDesc>Also count items on any colonist sent on a caravan, in transport pods, in cryptosleep chambers, or otherwise unavailable</IW.CountAwayDesc>
+
   <IW.CountInstalledLabel>Count installed items</IW.CountInstalledLabel>
   <IW.CountInstalledDesc>Also count items that have been installed as a building</IW.CountInstalledDesc>
 

--- a/dist/ImprovedWorkbenches/Languages/English/Keyed/IW_LanguageData.xml
+++ b/dist/ImprovedWorkbenches/Languages/English/Keyed/IW_LanguageData.xml
@@ -43,13 +43,16 @@
   <IW.CountCorpseClothesDesc>Include corpse worn clothing in item count</IW.CountCorpseClothesDesc>
 
   <IW.CountInventoryLabel>Count carried items</IW.CountInventoryLabel>
-  <IW.CountInventoryDesc>Also count items inventories or being carried</IW.CountInventoryDesc>
+  <IW.CountInventoryDesc>Also count items in inventories or being carried</IW.CountInventoryDesc>
 
   <IW.CountEquippedClothesLabel>Count equipped clothes</IW.CountEquippedClothesLabel>
   <IW.CountEquippedClothesDesc>Also count clothes currently worn by colonists</IW.CountEquippedClothesDesc>
 
   <IW.CountEquippedWeaponsLabel>Count equipped weapons</IW.CountEquippedWeaponsLabel>
   <IW.CountEquippedWeaponsDesc>Also count weapons currently equipped by colonists</IW.CountEquippedWeaponsDesc>
+
+  <IW.CountInstalledLabel>Count installed items</IW.CountInstalledLabel>
+  <IW.CountInstalledDesc>Also count items that have been installed as a building</IW.CountInstalledDesc>
 
   <IW.OpenPreviousBillTip>Open previous bill in workbench</IW.OpenPreviousBillTip>
 

--- a/dist/ImprovedWorkbenches/Languages/Japanese/Keyed/IW_LanguageData.xml
+++ b/dist/ImprovedWorkbenches/Languages/Japanese/Keyed/IW_LanguageData.xml
@@ -42,8 +42,8 @@
   <IW.CountCorpseClothesLabel>死者の衣服も含める</IW.CountCorpseClothesLabel>
   <IW.CountCorpseClothesDesc>アイテム数に死体の着ている衣服も含めます</IW.CountCorpseClothesDesc>
 
-  <IW.CountEquippedClothesLabel>装備中の衣服も含める</IW.CountEquippedClothesLabel>
-  <IW.CountEquippedClothesDesc>入植者が現在着ている服も数えます</IW.CountEquippedClothesDesc>
+  <IW.CountInventoryLabel>装備中の衣服も含める</IW.CountInventoryLabel>
+  <IW.CountInventoryDesc>入植者が現在着ている服も数えます</IW.CountInventoryDesc>
 
   <IW.OpenPreviousBillTip>前の加工命令を開く</IW.OpenPreviousBillTip>
 

--- a/dist/ImprovedWorkbenches/Languages/Russian/Keyed/IW_LanguageData.xml
+++ b/dist/ImprovedWorkbenches/Languages/Russian/Keyed/IW_LanguageData.xml
@@ -41,9 +41,9 @@
 	
 	<IW.CountCorpseClothesLabel>Учитывать одежду с трупов</IW.CountCorpseClothesLabel>
 	<IW.CountCorpseClothesDesc>Включать одежду на трупах при учете предметов</IW.CountCorpseClothesDesc>
-	
-	<IW.CountEquippedClothesLabel>Учитывать одежду на колонистах</IW.CountEquippedClothesLabel>
-	<IW.CountEquippedClothesDesc>Учитывать предметы одежды, на данный момент, надетые на колонистов</IW.CountEquippedClothesDesc>
+
+	<IW.CountInventoryLabel>Учитывать одежду на колонистах</IW.CountInventoryLabel>
+	<IW.CountInventoryDesc>Учитывать предметы одежды, на данный момент, надетые на колонистов</IW.CountInventoryDesc>
 
 	<IW.OpenPreviousBillTip>Открыть предыдущий проект на верстаке</IW.OpenPreviousBillTip>
 	

--- a/dist/ImprovedWorkbenches/Patches/ImprovedWorkbenches.xml
+++ b/dist/ImprovedWorkbenches/Patches/ImprovedWorkbenches.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef [@Name ="BasePawn"]/comps</xpath>
+		<value>
+            <li><compClass>ImprovedWorkbenches.CompPawnOriginalMap</compClass></li>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
Tracks inventory for any bill - meals, drugs, medicine, whatever. Also counts on pack animals! (Issue #31 thoroughly close)

This includes hauling items, so items carried away from a bill are immediately included in the bill count.

Consolidated the options to "Count colonist's items" - apparel, weapon, or whatever - everything on the colonist is checked.

A few fixes:
- Counting installed sculptures, as the base game does. Added an option to turn it off. Of course it counts hauling them as well, now.
- Bills look for items on their map, not the visible one - colony A would start work if colony B has low supplies.
- Fix bills forgetting their stockpiles on load - another map dependency.  (Fixes Issue #29)
- Fix copied bills across maps taking to imaginary zones - where the original bill's zone was, but the wrong map (There still is a problem or two with this, nothing too bad)