### PR TITLE
Enables ExportAgency to export/import BetterWorkshop settings (loses settings from old saves)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# top-most EditorConfig file
+root = true
+
+# 4 space indentation
+[*.{cs,xml}]
+indent_style = space
+indent_size = 4

--- a/src/ImprovedWorkbenches/Custom Storage/ExtendedBillData.cs
+++ b/src/ImprovedWorkbenches/Custom Storage/ExtendedBillData.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using RimWorld;
 using Verse;
+using Harmony;
 
 namespace ImprovedWorkbenches
 {
@@ -27,4 +28,30 @@ namespace ImprovedWorkbenches
             Scribe_Values.Look(ref Name, "name", null);
         }
     }
+
+
+    [HarmonyPatch(typeof(Bill_Production), nameof(Bill_Production.ExposeData))]
+    public static class ExtendedBillData_ExposeData
+    {
+        public static void Postfix(Bill_Production __instance)
+        {
+            var storage = HugsLib.Utils.UtilityWorldObjectManager.GetUtilityWorldObject<ExtendedBillDataStorage>();
+            storage.GetOrCreateExtendedDataFor(__instance).ExposeData();
+        }
+    }
+
+
+    [HarmonyPatch(typeof(Bill_Production), nameof(Bill_Production.Clone))]
+    public static class ExtendedBillData_Clone
+    {
+        public static void Postfix(Bill_Production __instance, Bill_Production __result)
+        {
+            var storage = Main.Instance.GetExtendedBillDataStorage();
+            var sourceExtendedData = storage.GetExtendedDataFor(__instance);
+            var destinationExtendedData = storage.GetOrCreateExtendedDataFor(__result);
+            
+            destinationExtendedData?.CloneFrom(sourceExtendedData, true);
+        }
+    }
+
 }


### PR DESCRIPTION
ExtendedBillData was stored in a WorldObject, which other mods don't know about. This moves ExtendedBillData to the Bill's ExposeData, so it is written alongside the bill, and then other mods have access to it.

This required a change to index the Data by Bill, not by Bill ID, which is not backward-compatible, and forgets ExtendedBillData settings from old saves (tried to migrate Bill info from the BillID#, but didn't seem doable.)

