### PR TITLE
add null checks for pawns and maps

### DIFF
--- a/src/ImprovedWorkbenches/Detours/Pawn_Spawn_Detour.cs
+++ b/src/ImprovedWorkbenches/Detours/Pawn_Spawn_Detour.cs
@@ -10,7 +10,7 @@ namespace ImprovedWorkbenches.Detours
     {
         public static void Prefix(Pawn __instance)
         {
-            if (__instance.Map.IsPlayerHome && (__instance.Faction?.IsPlayer ?? false))
+            if (__instance.Map?.IsPlayerHome ?? false && (__instance.Faction?.IsPlayer ?? false))
             {
                 __instance.SetOriginMap(__instance.Map);
             }


### PR DESCRIPTION
I was getting an error when pawns joined and left my map (visitors and nobility etc).