### PR TITLE
Master

### DIFF
--- a/src/ImprovedWorkbenches/Detours/Pawn_Spawn_Detour.cs
+++ b/src/ImprovedWorkbenches/Detours/Pawn_Spawn_Detour.cs
@@ -10,7 +10,7 @@ namespace ImprovedWorkbenches.Detours
     {
         public static void Prefix(Pawn __instance)
         {
-            if (__instance.Map?.IsPlayerHome ?? false && (__instance.Faction?.IsPlayer ?? false))
+            if ((__instance?.Map?.IsPlayerHome ?? false) && (__instance?.Faction?.IsPlayer ?? false))
             {
                 __instance.SetOriginMap(__instance.Map);
             }


### PR DESCRIPTION
fix parenthesis on the DeSpawn Prefix. ?? has a lower priority than && so the 2nd half of the if was never getting executed.