### PR TITLE
Fix Null Pointer Error when Importing Bills Into New Game with Export Agency

### DIFF
--- a/src/ImprovedWorkbenches/Custom Storage/ExtendedBillData.cs
+++ b/src/ImprovedWorkbenches/Custom Storage/ExtendedBillData.cs
@@ -18,13 +18,16 @@ namespace ImprovedWorkbenches
 
         public void CloneFrom(ExtendedBillData other, bool cloneName)
         {
-            CountAway = other.CountAway;
-            ProductAdditionalFilter = new ThingFilter();
-            if(other.ProductAdditionalFilter != null)
-                ProductAdditionalFilter.CopyAllowancesFrom(other.ProductAdditionalFilter);
+            if (other != null)
+            {
+                CountAway = other.CountAway;
+                ProductAdditionalFilter = new ThingFilter();
+                if (other.ProductAdditionalFilter != null)
+                    ProductAdditionalFilter.CopyAllowancesFrom(other.ProductAdditionalFilter);
 
-            if (cloneName)
-                Name = other.Name;
+                if (cloneName)
+                    Name = other.Name;
+            }
         }
 
         public void ExposeData()


### PR DESCRIPTION
Fix Null Pointer Error when Importing Bills Into New Game with Export Agency

Export Agency is another mod which lets you Export a workbench full of bills from one game into separate file and then Import them onto another workbench in possibly another game.

https://steamcommunity.com/sharedfiles/filedetails/?id=1467209473

For me it wasn't working, it was conflicting with this mod, it was throwing a null pointer. This fixes it.

Granted, I just wrappered the function in a null check, essentially disabling the function, and so my newly imported bills did not carry forward their previous CountAway or Name or AdditionalFilter, but hey, I got the basic bills in, which is good enough for me.