### PR TITLE
If settings allow, count items outside of stockpiles even for "count additional products"

### DIFF
--- a/src/ImprovedWorkbenches/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
+++ b/src/ImprovedWorkbenches/Detours/RecipeWorkerCounter_CountProducts_Detour.cs
@@ -140,6 +140,11 @@ namespace ImprovedWorkbenches
                     {
                         count += CountPawnThings(pawn, counter, bill, def, true);
                     }
+
+                    if (Main.Instance.ShouldCountOutsideStockpiles())
+                    {
+                        count += GetMatchingItemCountOutsideStockpiles(bill, def);
+                    }
                 }
                 else if (bill.includeFromZone == null)
                 {


### PR DESCRIPTION
fix #99 
