### PR TITLE
Add integration with [LTO] Colony Groups

### DIFF
--- a/src/ImprovedWorkbenches/Custom Storage/ExtendedBillDataStorage.cs
+++ b/src/ImprovedWorkbenches/Custom Storage/ExtendedBillDataStorage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -201,6 +202,36 @@ namespace ImprovedWorkbenches
             destinationBill.SetStoreMode(sourceBill.GetStoreMode(), sourceBill.GetSlotGroup());
             destinationBill.paused = sourceBill.paused;
             destinationBill.SetPawnRestriction(sourceBill.PawnRestriction);
+
+            // Colony Groups integration
+            if (Main.Instance.ColonyGroupsBillToPawnGroupDictGetter != null)
+            {
+                try
+                {
+                    var billToPawnGroupDict = Main.Instance.ColonyGroupsBillToPawnGroupDictGetter();
+
+                    if (billToPawnGroupDict.Contains(sourceBill))
+                    {
+                        var pawnGroup = billToPawnGroupDict[sourceBill];
+                        // Main.Instance.Logger.Message(
+                        //     $"Setting PawnGroup of bill {destinationBill} to that of {sourceBill} ({pawnGroup})");
+                        billToPawnGroupDict[destinationBill] = pawnGroup;
+                    }
+                    else
+                    {
+                        // Main.Instance.Logger.Message(
+                        //     $"Removing PawnGroup assignment of bill {destinationBill} to mirror bill {sourceBill}");
+                        billToPawnGroupDict.Remove(destinationBill);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Main.Instance.Logger.ReportException(
+                        e, reportOnceOnly: true,
+                        location:
+                        "attempt to copy pawn group assignment of a bill to another bill (ColonyGroups integration)");
+                }
+            }
 
             if (Main.Instance.ShouldMirrorSuspendedStatus())
             {


### PR DESCRIPTION
Hi, thanks for the great mod, can hardly play without it.

This patch adds integration with  [LTO] Colony Groups. That mod allows you to create a group of pawns, then assign a bill to this group in the same way you would assign a bill to a single pawn in vanilla.

Currently, such pawn group assignments are not mirrored to linked bills, and not copied using BWM's copy/paste of bill settings. This patch fixes that.

Tested in my actual save; works fine so far.

The implementation directly accesses a dictionary in Colony Groups, which is brittle to future changes in Colony Groups. Ideally, there should be a stable `CopyBillSettings(Bill src, Bill dest)` method in ColonyGroups, but unfortunately I haven't found a source repo.

My name on the Rimworld Discord is "dunno".