### PR TITLE
Small improvements: Renaming bill allow to edit current name and copying "butcher creature" now allow copying "until X" condition 

### DIFF
--- a/src/ImprovedWorkbenches/Custom Names/Dialog_RenameBill.cs
+++ b/src/ImprovedWorkbenches/Custom Names/Dialog_RenameBill.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using RimWorld;
+using Verse;
 
 namespace ImprovedWorkbenches
 {
@@ -7,14 +8,25 @@ namespace ImprovedWorkbenches
         private readonly ExtendedBillData _extendedBill;
 
 
-        public Dialog_RenameBill(ExtendedBillData extendedBill) : base(null)
+        public Dialog_RenameBill(ExtendedBillData extendedBill, Bill_Production bill) : base(null)
         {
              _extendedBill = extendedBill;
+
+            if (string.IsNullOrEmpty(_extendedBill.Name))
+            {
+                curName = bill.LabelCap;
+            }
+            else
+            {
+                curName = _extendedBill.Name;
+            }
         }
 
         protected override void OnRenamed(string name)
         {
             _extendedBill.Name = name;
         }
+
+
     }
 }

--- a/src/ImprovedWorkbenches/Custom Storage/ExtendedBillDataStorage.cs
+++ b/src/ImprovedWorkbenches/Custom Storage/ExtendedBillDataStorage.cs
@@ -209,7 +209,8 @@ namespace ImprovedWorkbenches
 
             var outputCanBeFiltered =
                 CanOutputBeFiltered(destinationBill)
-                || destinationBill.recipe?.WorkerCounter is RecipeWorkerCounter_MakeStoneBlocks;
+                || destinationBill.recipe?.WorkerCounter is RecipeWorkerCounter_MakeStoneBlocks
+                || destinationBill.recipe?.WorkerCounter is RecipeWorkerCounter_ButcherAnimals;
 
             if (sourceBill.repeatMode != BillRepeatModeDefOf.TargetCount || outputCanBeFiltered)
             {

--- a/src/ImprovedWorkbenches/Detours/BillConfig_DoWindowContents_Patch.cs
+++ b/src/ImprovedWorkbenches/Detours/BillConfig_DoWindowContents_Patch.cs
@@ -75,7 +75,7 @@ namespace ImprovedWorkbenches
                 var renameRect = new Rect(inRect.xMax - 75f, inRect.yMin + 4f, 24f, 24f);
                 if (Widgets.ButtonImage(renameRect, Resources.Rename))
                 {
-                    Find.WindowStack.Add(new Dialog_RenameBill(extendedBillData));
+                    Find.WindowStack.Add(new Dialog_RenameBill(extendedBillData, billRaw));
                 }
                 TooltipHandler.TipRegion(renameRect, "IW.RenameBillTip".Translate());
             }


### PR DESCRIPTION
When a bill is renamed, the renaming windows shows current custom name or original bill's name

![example](https://github.com/user-attachments/assets/d345816a-9be7-4612-a853-1e35d9b68e85)

Previously, when renaming a bill the default new name was always empty.

Also allowed to copy the "until X" condition for "butcher creature" order